### PR TITLE
Extend mce struct with IPID,SYND and also write those to v2 clients

### DIFF
--- a/mced.c
+++ b/mced.c
@@ -584,6 +584,8 @@ kmce_to_mce(struct kernel_mce *kmce, struct mce *mce)
 	mce->mci_status = kmce->status;
 	mce->mci_address = kmce->addr;
 	mce->mci_misc = kmce->misc;
+	mce->mci_synd = kmce->synd;
+	mce->mci_ipid = kmce->ipid;
 	mce->mcg_status = kmce->mcgstatus;
 	mce->tsc = kmce->tsc;
 	mce->cs = kmce->cs;

--- a/mced.h
+++ b/mced.h
@@ -105,6 +105,8 @@ struct mce {
 	uint64_t mci_status;	/* MCi_STATUS */
 	uint64_t mci_address;	/* MCi_ADDR */
 	uint64_t mci_misc;	/* MCi_MISC */
+	uint64_t mci_synd;	/* MCi_SYND (Syndrome; SMCA-only) */
+	uint64_t mci_ipid;	/* MCi_IPID (IP Identification; SMCA-only) */
 	uint64_t mcg_status;	/* MCG_STATUS */
 	uint64_t tsc;		/* CPU timestamp counter */
 	uint64_t time;		/* MCED timestamp (usecs since epoch) */
@@ -119,7 +121,7 @@ struct mce {
 	uint8_t  bank;		/* MC bank */
 	int8_t   vendor;	/* CPU vendor (enum cpu_vendor) */
 } __attribute__ ((packed));
-#define MCE_STRUCT_VER	1
+#define MCE_STRUCT_VER	2
 
 /* bits from the MCi_STATUS register */
 #define MCI_STATUS_OVER		(1ULL<<62)	/* errors overflowed */

--- a/rules.c
+++ b/rules.c
@@ -720,6 +720,8 @@ do_v2_client_rule(struct rule *rule, struct mce *mce)
 		 " %%s=0x%016llx"		// mci_status
 		 " %%a=0x%016llx"		// mci_address
 		 " %%m=0x%016llx"		// mci_misc
+		 " %%y=0x%016llx"		// mci_synd
+		 " %%i=0x%016llx"		// mci_ipid
 		 " %%g=0x%016llx"		// mcg_status
 		 " %%G=0x%08lx"			// mcg_cap
 		 " %%t=0x%016llx"		// time
@@ -734,6 +736,8 @@ do_v2_client_rule(struct rule *rule, struct mce *mce)
 		 (unsigned long long)mce->mci_status,
 		 (unsigned long long)mce->mci_address,
 		 (unsigned long long)mce->mci_misc,
+		 (unsigned long long)mce->mci_synd,
+		 (unsigned long long)mce->mci_ipid,
 		 (unsigned long long)mce->mcg_status,
 		 (unsigned long)mce->mcg_cap,
 		 (unsigned long long)mce->time,
@@ -786,6 +790,8 @@ safe_write(int fd, const char *buf, int len)
  * 	%s	- MCi status
  * 	%a	- MCi address
  * 	%m	- MCi misc
+ * 	%y	- MCi synd
+ * 	%i	- MCi ipid
  * 	%g	- MCG status
  * 	%G	- MCG capabilities
  * 	%t	- time
@@ -852,6 +858,16 @@ parse_cmd(const char *cmd, struct mce *mce)
 				used += snprintf(buf+used, size,
 				    "0x%016llx",
 				    (unsigned long long)mce->mci_misc);
+			} else if (*p == 'y') {
+				/* mci_synd */
+				used += snprintf(buf+used, size,
+				    "0x%016llx",
+				    (unsigned long long)mce->mci_synd);
+			} else if (*p == 'i') {
+				/* mci_ipid */
+				used += snprintf(buf+used, size,
+				    "0x%016llx",
+				    (unsigned long long)mce->mci_ipid);
 			} else if (*p == 'g') {
 				/* mcg_status */
 				used += snprintf(buf+used, size,


### PR DESCRIPTION
These new fields are useful for platforms that use SMCA.
Tested using platform mce injection with mce_listen. Also sanity checked the parse_cmd change with a simple "echo" rule.
/cc @jmeurin 