### PR TITLE
mce: add support to build deb

### DIFF
--- a/deb.sh
+++ b/deb.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "configure" ]; then
+  if [ "$2" = "" ]; then
+    # install
+    systemctl enable mced.service >/dev/null 2>&1 || :
+    if [ -d /run/systemd/system ]; then
+      systemctl start mced.service >/dev/null 2>&1 || :
+    fi
+  else
+    # upgrade
+    if [ -d /run/systemd/system ]; then
+      systemctl try-restart mced.service >/dev/null 2>&1 || :
+    fi
+  fi
+elif [ "$1" = "remove" ]; then
+  # uninstall
+  systemctl --no-reload disable mced.service >/dev/null 2>&1 || :
+  if [ -d /run/systemd/system ]; then
+    systemctl stop mced.service >/dev/null 2>&1 || :
+  fi
+else
+  # abort-upgrade, abort-remove, upgrade, failed-upgrade
+  :
+fi
+
+exit 0

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+set -e
+
+NAME=mcedaemon
+VERSION=$1
+PACKAGE_REV=$2
+FULLNAME=${NAME}-${VERSION}-${PACKAGE_REV}
+
+sudo rm -rf /tmp/${FULLNAME}
+mkdir --mode=0755 /tmp/${FULLNAME}
+mkdir --mode=0755 /tmp/${FULLNAME}/DEBIAN
+
+cat <<EOF > /tmp/${FULLNAME}/DEBIAN/control
+Package: ${NAME}
+Version: ${VERSION}
+Architecture: amd64
+Section: contrib/admin
+Priority: optional
+Installed-Size: 64
+Maintainer: nobody@google.com
+Description: mced watches the system for machine check exceptions.
+EOF
+
+cp deb.sh /tmp/${FULLNAME}/DEBIAN/postinst
+chmod 0775 /tmp/${FULLNAME}/DEBIAN/postinst
+cp deb.sh /tmp/${FULLNAME}/DEBIAN/prerm
+chmod 0775 /tmp/${FULLNAME}/DEBIAN/prerm
+
+mkdir --mode=0755 /tmp/${FULLNAME}/usr
+mkdir --mode=0755 /tmp/${FULLNAME}/usr/bin
+
+cp mced /tmp/${FULLNAME}/usr/bin/
+chmod 0755 /tmp/${FULLNAME}/usr/bin/mced
+cp mce_listen /tmp/${FULLNAME}/usr/bin/
+chmod 0755 /tmp/${FULLNAME}/usr/bin/mce_listen
+
+mkdir --mode=0755 /tmp/${FULLNAME}/etc
+mkdir --mode=0755 /tmp/${FULLNAME}/etc/systemd
+mkdir --mode=0755 /tmp/${FULLNAME}/etc/systemd/system
+
+cp mced.service /tmp/${FULLNAME}/etc/systemd/system/
+chmod 0644 /tmp/${FULLNAME}/etc/systemd/system/mced.service
+
+mkdir --mode=0755 /tmp/${FULLNAME}/etc/mced
+
+cp examples/mce_decode.conf /tmp/${FULLNAME}/etc/mced/
+chmod 0644 /tmp/${FULLNAME}/etc/mced/mce_decode.conf
+cp examples/mcelog.conf /tmp/${FULLNAME}/etc/mced/
+chmod 0644 /tmp/${FULLNAME}/etc/mced/mcelog.conf
+
+chmod o+r -R /tmp/${FULLNAME}
+sudo chown root:root -R /tmp/${FULLNAME}
+
+dpkg-deb --build /tmp/${FULLNAME} ./
+
+# dpkg -c archive to list contents
+# -e archive [dir] to extract control info
+# -x archive dir to exact files
+# -I archive to show info about package
+
+sudo rm -rf /tmp/${FULLNAME}

--- a/mced.spec
+++ b/mced.spec
@@ -16,12 +16,11 @@
 
 # Don't build debuginfo packages.
 %define debug_package %{nil}
-%define version 2.0.5
 
 Name: mcedaemon
 Epoch:   1
 Version: %{version}
-Release: 1%{?dist}
+Release: %{revision}%{?dist}
 Summary: mced watches the system for machine check exceptions.
 License: GPL2
 Url: https://github.com/thockin/mcedaemon
@@ -35,7 +34,7 @@ mced is a very small daemon which monitors /dev/mcelog for machine check events,
 %autosetup
 
 %build
-make
+make STATIC=1
 
 %install
 install -d %{buildroot}%{_bindir}


### PR DESCRIPTION
This change adds support for creating rpm and deb installer packages
using make.  The binaries are created with static linking in order to increase
portability.  rpmbuild seems insistent that the tar file be called mcedaemon
rather than mced so I also changed the dist rule to match this.